### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests
@@ -98,6 +101,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [tests, eslint, types]
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/isyuricunha/website-apps/security/code-scanning/10](https://github.com/isyuricunha/website-apps/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for most jobs, as they primarily involve checking out code, running tests, and uploading artifacts. For jobs that require additional permissions (e.g., uploading artifacts), we will explicitly define those permissions within the respective job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
