### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
 name: Release
+permissions:
+  contents: read
+  pull-requests: write
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/isyuricunha/website-apps/security/code-scanning/7](https://github.com/isyuricunha/website-apps/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating or updating pull requests.
- `packages: write` for publishing to NPM.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
