### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,5 +1,9 @@
 name: deploy release and notes / change logs
 
+permissions:
+  contents: write
+  actions: read
+
 on:
   push:
     branches: main


### PR DESCRIPTION
Potential fix for [https://github.com/isyuricunha/website-apps/security/code-scanning/3](https://github.com/isyuricunha/website-apps/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: write` for tagging and creating releases.
- `actions: read` for accessing workflow artifacts.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
